### PR TITLE
Use System.Data.SqlClient.

### DIFF
--- a/Mindbox.Data.Linq.Tests/packages.config
+++ b/Mindbox.Data.Linq.Tests/packages.config
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net472" />
-  <package id="Microsoft.Data.SqlClient" version="2.1.3" targetFramework="net472" />
-  <package id="Microsoft.Data.SqlClient.SNI" version="2.1.1" targetFramework="net472" />
+  <package id="System.Data.SqlClient" version="4.8.2" targetFramework="net472" />
   <package id="Microsoft.Identity.Client" version="4.21.1" targetFramework="net472" />
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" targetFramework="net472" />
   <package id="Microsoft.IdentityModel.Logging" version="6.8.0" targetFramework="net472" />

--- a/Mindbox.Data.Linq/DbConvert.cs
+++ b/Mindbox.Data.Linq/DbConvert.cs
@@ -1,5 +1,5 @@
 using System.Data.Common;
-using Microsoft.Data.SqlClient;
+using System.Data.SqlClient;
 using System.Linq.Expressions;
 using System.IO;
 using System.Reflection;

--- a/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
+++ b/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
@@ -12,14 +12,14 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageVersion>4.0.0</PackageVersion>
+    <PackageVersion>5.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.3" />
     <PackageReference Include="Mindbox.Expressions" Version="3.2.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />

--- a/Mindbox.Data.Linq/SqlClient/Common/Expressions.cs
+++ b/Mindbox.Data.Linq/SqlClient/Common/Expressions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using Microsoft.Data.SqlClient;
+using System.Data.SqlClient;
 using System.Linq.Expressions;
 using System.Linq;
 using System.Reflection;

--- a/Mindbox.Data.Linq/SqlClient/Query/SqlFormatter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/SqlFormatter.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Data.Linq.Mapping;
 using System.Data.Linq.Provider;
 using System.Linq;
-using Microsoft.Data.SqlClient;
+using System.Data.SqlClient;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Data.Linq.SqlClient {

--- a/Mindbox.Data.Linq/SqlClient/Query/SqlIdentifier.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/SqlIdentifier.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Linq.Mapping;
 using System.Data.Linq.Provider;
-using Microsoft.Data.SqlClient;
+using System.Data.SqlClient;
 using System.Globalization;
 using System.Linq;
 using System.Text;

--- a/Mindbox.Data.Linq/SqlClient/Reader/ObjectReaderCompiler.cs
+++ b/Mindbox.Data.Linq/SqlClient/Reader/ObjectReaderCompiler.cs
@@ -14,7 +14,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Data.Linq.SqlClient.Implementation;
-using Microsoft.Data.SqlClient;
+using System.Data.SqlClient;
 using System.Diagnostics.CodeAnalysis;
 using Mindbox.Data.Linq.Proxy;
 using Mindbox.Expressions;

--- a/Mindbox.Data.Linq/SqlClient/SqlBuilder.cs
+++ b/Mindbox.Data.Linq/SqlClient/SqlBuilder.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Microsoft.Data.SqlClient;
+using System.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;

--- a/Mindbox.Data.Linq/SqlClient/SqlConnectionManager.cs
+++ b/Mindbox.Data.Linq/SqlClient/SqlConnectionManager.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using Microsoft.Data.SqlClient;
+using System.Data.SqlClient;
 using System.Linq.Expressions;
 using System.IO;
 using System.Reflection;

--- a/Mindbox.Data.Linq/SqlClient/SqlProvider.cs
+++ b/Mindbox.Data.Linq/SqlClient/SqlProvider.cs
@@ -8,7 +8,7 @@ using System.Data.Common;
 using System.Data.Linq;
 using System.Data.Linq.Mapping;
 using System.Data.Linq.Provider;
-using Microsoft.Data.SqlClient;
+using System.Data.SqlClient;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -1141,7 +1141,7 @@ namespace System.Data.Linq.SqlClient {
                     if (piScale != null) {
                         scale = (int)Convert.ChangeType(piScale.GetValue(p, null), typeof(int), CultureInfo.InvariantCulture);
                     }                
-                    var sp = p as Microsoft.Data.SqlClient.SqlParameter;
+                    var sp = p as System.Data.SqlClient.SqlParameter;
                     writer.WriteLine("-- {0}: {1} {2} (Size = {3}; Prec = {4}; Scale = {5}) [{6}]", 
                         p.ParameterName, 
                         p.Direction, 

--- a/Mindbox.Data.Linq/SqlClient/SqlTypeSystemProvider.cs
+++ b/Mindbox.Data.Linq/SqlClient/SqlTypeSystemProvider.cs
@@ -974,7 +974,7 @@ namespace System.Data.Linq.SqlClient {
                     throw Error.BadParameterType(sqlType.GetClosestRuntimeType());
                 }
 
-                if (parameter is Microsoft.Data.SqlClient.SqlParameter sParameter) {
+                if (parameter is System.Data.SqlClient.SqlParameter sParameter) {
                     sParameter.SqlDbType = sqlType.SqlDbType;
                     if (sqlType.HasPrecisionAndScale) {
                         sParameter.Precision = (byte)sqlType.Precision;


### PR DESCRIPTION
The Microsoft.Data.SqlClient component uses a native assembly to talk to SQL Server instances.
Unfortunately, it uses the [DllImport] attribute to P/Invoke into native code - this means that the IIS process locks the file and there is no way to release the lock other than forcibly shut down the worker process (i.e. restarting the Application Pools).
This behavior breaks the IIS xcopy deployment model.

https://github.com/dotnet/SqlClient/issues/354