### PR TITLE
При override'е Identity смотрим на аттрибут IdentityInsertColumnIdentifier вместо MigrationIdentifier

### DIFF
--- a/Mindbox.Data.Linq/Mapping/AttributedMetaDataMember.cs
+++ b/Mindbox.Data.Linq/Mapping/AttributedMetaDataMember.cs
@@ -294,6 +294,8 @@ namespace System.Data.Linq.Mapping
 
 		public string MigrationIdentifier => columnAttribute?.MigrationIdentifier;
 
+		public string IdentityInsertColumnIdentifier => columnAttribute?.IdentityInsertColumnIdentifier;
+
 		public override string Expression => columnAttribute?.Expression;
 
 		public override string MappedName

--- a/Mindbox.Data.Linq/Mapping/ColumnAttribute.cs
+++ b/Mindbox.Data.Linq/Mapping/ColumnAttribute.cs
@@ -23,6 +23,7 @@
 		public AutoSync AutoSync { get; set; }
 		public bool IsDiscriminator { get; set; }
 		public string MigrationIdentifier { get; set; }
+		public string IdentityInsertColumnIdentifier { get; set; }
 
 		public bool CanBeNull
 		{

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -2414,10 +2414,10 @@ namespace System.Data.Linq.SqlClient {
             foreach (var metaMember in itemMetaType.PersistentDataMembers)
             {
 	            if (metaMember.IsDbGenerated && metaMember is AttributedMetaDataMember attributedMetaMember &&
-	                attributedMetaMember.MigrationIdentifier != null &&
+	                attributedMetaMember.IdentityInsertColumnIdentifier != null &&
 	                metaTable.Model is MindboxMetaModel mindboxMetaModel &&
 	                mindboxMetaModel.ShouldOverrideGeneratedColumn(attributedMetaMember
-		                .MigrationIdentifier))
+		                .IdentityInsertColumnIdentifier))
 	            {
 		            shouldOverrideGeneratedColumn = true;
 	            }


### PR DESCRIPTION
Столкнулись с [проблемой](https://mindbox.slack.com/archives/C010103H3MH/p1674137500286759?thread_ts=1674134297.146819&cid=C010103H3MH) из-за которой не можем завязаться на MigrationIdentifier