### PR TITLE
fix: handle InvocationExpression pattern for MemoryExtensions.Contains (.NET 10)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,9 +10,9 @@ jobs:
         uses: actions/checkout@v1      
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
 
       - name: Install dependencies
         run: dotnet restore          

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,9 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Install dependencies
         run: dotnet restore          
@@ -21,4 +23,4 @@ jobs:
         run: dotnet build ./Mindbox.Data.Linq.sln --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --no-restore          
+        run: dotnet test --no-restore

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,9 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>12</LangVersion>
+    <Company>Mindbox</Company>
+    <Authors>Mindbox</Authors>
+    <Copyright>Copyright 2019 (c) Mindbox</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,12 +6,12 @@
   <ItemGroup>
     <PackageVersion Include="Castle.Core" Version="5.1.1" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Mindbox.Expressions" Version="3.3.0" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.11.1" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.11.1" />
     <PackageVersion Include="System.Security.Permissions" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,17 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Castle.Core" Version="5.1.1" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="Mindbox.Expressions" Version="3.3.0" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageVersion Include="System.Security.Permissions" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="Mindbox.Expressions" Version="3.3.0" />
+    <PackageVersion Include="Mindbox.Expressions" Version="3.3.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.11.1" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.11.1" />

--- a/Mindbox.Data.Linq.Tests/Mindbox.Data.Linq.Tests.csproj
+++ b/Mindbox.Data.Linq.Tests/Mindbox.Data.Linq.Tests.csproj
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RootNamespace>Mindbox.Data.Linq.Tests</RootNamespace>
-    <TargetFramework />
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <RootNamespace>Mindbox.Data.Linq.Tests</RootNamespace>
     <AssemblyName>Mindbox.Data.Linq.Tests</AssemblyName>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <Company>mindbox.ru</Company>
-    <Product>Itc.Nexus</Product>
-    <NeutralLanguage>ru</NeutralLanguage>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/Mindbox.Data.Linq.Tests/Mindbox.Data.Linq.Tests.csproj
+++ b/Mindbox.Data.Linq.Tests/Mindbox.Data.Linq.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Mindbox.Data.Linq.Tests</RootNamespace>
     <AssemblyName>Mindbox.Data.Linq.Tests</AssemblyName>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Company>mindbox.ru</Company>
@@ -12,6 +12,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <NoWarn>CS0169</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mindbox.Data.Linq\Mindbox.Data.Linq.csproj" />

--- a/Mindbox.Data.Linq.Tests/Mindbox.Data.Linq.Tests.csproj
+++ b/Mindbox.Data.Linq.Tests/Mindbox.Data.Linq.Tests.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Mindbox.Data.Linq.Tests</RootNamespace>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <AssemblyName>Mindbox.Data.Linq.Tests</AssemblyName>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/Mindbox.Data.Linq.Tests/Mindbox.Data.Linq.Tests.csproj
+++ b/Mindbox.Data.Linq.Tests/Mindbox.Data.Linq.Tests.csproj
@@ -1,9 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Mindbox.Data.Linq.Tests</RootNamespace>
     <AssemblyName>Mindbox.Data.Linq.Tests</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
     <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Company>mindbox.ru</Company>
@@ -16,9 +15,9 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mindbox.Data.Linq\Mindbox.Data.Linq.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
 </Project>

--- a/Mindbox.Data.Linq.Tests/Mindbox.Data.Linq.Tests.csproj
+++ b/Mindbox.Data.Linq.Tests/Mindbox.Data.Linq.Tests.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>Mindbox.Data.Linq.Tests</RootNamespace>
+    <TargetFramework />
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <AssemblyName>Mindbox.Data.Linq.Tests</AssemblyName>
     <Deterministic>false</Deterministic>
@@ -9,7 +10,7 @@
     <Company>mindbox.ru</Company>
     <Product>Itc.Nexus</Product>
     <NeutralLanguage>ru</NeutralLanguage>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <NoWarn>CS0169</NoWarn>

--- a/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
+++ b/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
@@ -9,6 +9,10 @@ namespace Mindbox.Data.Linq.Tests
 	/// Tests that array.Contains(value) in LINQ queries is correctly translated to SQL IN clause.
 	/// In .NET 10, the C# compiler generates MemoryExtensions.Contains(ReadOnlySpan, value)
 	/// for this pattern instead of Enumerable.Contains — this must produce the same SQL.
+	/// Two compiler patterns exist:
+	/// 1. MethodCallExpression(op_Implicit, array) — simple closure capture
+	/// 2. InvocationExpression(ConstantExpression(delegate), []) — pre-compiled closure
+	/// Both must be handled.
 	/// </summary>
 	[TestClass]
 	public class ArrayContainsTranslationTests
@@ -22,6 +26,35 @@ namespace Mindbox.Data.Linq.Tests
 			using var context = new DataContext(connection);
 
 			var query = context.GetTable<SimpleEntity>().Where(t => ids.Contains(t.Id));
+
+			using var command = context.GetCommand(query);
+
+			Assert.AreEqual(
+				"SELECT [t0].[Id], [t0].[Discriminator], [t0].[X]" + Environment.NewLine +
+				"FROM [SimpleTable] AS [t0]" + Environment.NewLine +
+				"WHERE [t0].[Id] IN (@p0, @p1, @p2)",
+				command.CommandText);
+		}
+
+		/// <summary>
+		/// Reproduces the InvocationExpression pattern: when array is passed as a parameter
+		/// to a helper method and used in a Where clause, .NET 10 compiler may generate
+		/// InvocationExpression(ConstantExpression(pre_compiled_delegate), []) instead of
+		/// MethodCallExpression(op_Implicit, array_expr) for the implicit T[]→ReadOnlySpan conversion.
+		/// </summary>
+		[TestMethod]
+		public void ArrayContains_PassedAsParameter_TranslatesToSqlIn()
+		{
+			TranslateContainsQuery(new[] { 1, 2, 3 });
+		}
+
+		private static void TranslateContainsQuery(int[] ids)
+		{
+			using var connection = new DbConnectionStub();
+			using var context = new DataContext(connection);
+
+			var query = context.GetTable<SimpleEntity>()
+				.Where(t => ids.Contains(t.Id));
 
 			using var command = context.GetCommand(query);
 

--- a/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
+++ b/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Data.Linq;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Mindbox.Data.Linq.Tests.SqlGeneration
+{
+	/// <summary>
+	/// Tests that array.Contains(value) in LINQ queries is correctly translated to SQL IN clause.
+	/// In .NET 10, the C# compiler generates MemoryExtensions.Contains(ReadOnlySpan, value)
+	/// for this pattern instead of Enumerable.Contains — this must produce the same SQL.
+	/// </summary>
+	[TestClass]
+	public class ArrayContainsTranslationTests
+	{
+		[TestMethod]
+		public void ArrayContains_TranslatesToSqlIn()
+		{
+			var ids = new[] { 1, 2, 3 };
+
+			using var connection = new DbConnectionStub();
+			using var context = new DataContext(connection);
+
+			var query = context.GetTable<SimpleEntity>().Where(t => ids.Contains(t.Id));
+
+			using var command = context.GetCommand(query);
+
+			Assert.AreEqual(
+				"SELECT [t0].[Id], [t0].[Discriminator], [t0].[X]" + Environment.NewLine +
+				"FROM [SimpleTable] AS [t0]" + Environment.NewLine +
+				"WHERE [t0].[Id] IN (@p0, @p1, @p2)",
+				command.CommandText);
+		}
+
+		[TestMethod]
+		public void ArrayContains_EmptyArray_TranslatesToFalse()
+		{
+			var ids = Array.Empty<int>();
+
+			using var connection = new DbConnectionStub();
+			using var context = new DataContext(connection);
+
+			var query = context.GetTable<SimpleEntity>().Where(t => ids.Contains(t.Id));
+
+			using var command = context.GetCommand(query);
+
+			Assert.AreEqual(
+				"SELECT [t0].[Id], [t0].[Discriminator], [t0].[X]" + Environment.NewLine +
+				"FROM [SimpleTable] AS [t0]" + Environment.NewLine +
+				"WHERE 0 = 1",
+				command.CommandText);
+		}
+	}
+}

--- a/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
+++ b/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
@@ -3,7 +3,7 @@ using System.Data.Linq;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Mindbox.Data.Linq.Tests.SqlGeneration
+namespace Mindbox.Data.Linq.Tests
 {
 	/// <summary>
 	/// Tests that array.Contains(value) in LINQ queries is correctly translated to SQL IN clause.

--- a/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
+++ b/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
@@ -8,7 +8,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageVersion>10.8.0$(VersionTag)</PackageVersion>
+    <PackageVersion>10.8.1$(VersionTag)</PackageVersion>
     <NoWarn>SYSLIB0003;SYSLIB0011</NoWarn>
   </PropertyGroup>
 

--- a/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
+++ b/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
@@ -1,12 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageId>Mindbox.Data.Linq</PackageId>
-    <Company>Mindbox</Company>
     <Version>3.2.0</Version>
     <Description>A clone of Microsoft System.Data.Linq to allow multi-DLL extensibility and EF compatibility.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright 2019 (c) Mindbox</Copyright>
-    <Authors>Mindbox</Authors>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
+++ b/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
@@ -1,25 +1,24 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-	<PackageId>Mindbox.Data.Linq</PackageId>
+    <PackageId>Mindbox.Data.Linq</PackageId>
     <Company>Mindbox</Company>
     <Version>3.2.0</Version>
     <Description>A clone of Microsoft System.Data.Linq to allow multi-DLL extensibility and EF compatibility.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>Copyright 2019 (c) Mindbox</Copyright>
     <Authors>Mindbox</Authors>
-    <LangVersion>12</LangVersion>
-    <NoWarn>SYSLIB0011</NoWarn>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageVersion>10.8.0$(VersionTag)</PackageVersion>
+    <NoWarn>SYSLIB0003;SYSLIB0011</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="5.1.1" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
-    <PackageReference Include="Mindbox.Expressions" Version="3.3.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Castle.Core" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="Mindbox.Expressions" />
+    <PackageReference Include="System.Security.Permissions" />
   </ItemGroup>
 </Project>

--- a/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
+++ b/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<PackageId>Mindbox.Data.Linq</PackageId>
     <Company>Mindbox</Company>
     <Version>3.2.0</Version>
@@ -8,23 +8,18 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>Copyright 2019 (c) Mindbox</Copyright>
     <Authors>Mindbox</Authors>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>12</LangVersion>
+    <NoWarn>SYSLIB0011</NoWarn>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageVersion>10.7.2$(VersionTag)</PackageVersion>
+    <PackageVersion>10.8.0$(VersionTag)</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="5.1.1" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
     <PackageReference Include="Mindbox.Expressions" Version="3.3.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="System.Security.Permissions" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -1879,6 +1879,17 @@ namespace System.Data.Linq.SqlClient {
                 if (this.IsSequenceOperatorCall(mc)) {
                     return this.VisitSequenceOperatorCall(mc);
                 }
+                // In .NET 10, array.Contains(value) in expression trees compiles to
+                // MemoryExtensions.Contains(ReadOnlySpan<T>.op_Implicit(array), value).
+                // Translate the same as Enumerable.Contains(array, value).
+                else if (mc.Method.DeclaringType == typeof(MemoryExtensions)
+                    && mc.Method.Name == "Contains"
+                    && mc.Arguments.Count == 2
+                    && mc.Arguments[0] is MethodCallExpression spanConversion
+                    && spanConversion.Method.Name == "op_Implicit"
+                    && spanConversion.Arguments.Count == 1) {
+                    return this.VisitContains(spanConversion.Arguments[0], mc.Arguments[1]);
+                }
                 else if (IsDataManipulationCall(mc)) {
                     return this.VisitDataManipulationCall(mc);
                 }

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -1774,6 +1774,38 @@ namespace System.Data.Linq.SqlClient {
             return new SqlUnary(aggType, clrType, sqlType, exp, this.dominatingExpression);
         }
 
+        /// <summary>
+        /// Extracts the underlying array/collection expression from a ReadOnlySpan expression.
+        /// In .NET 10, array.Contains() may generate two patterns for the implicit T[]→ReadOnlySpan conversion:
+        ///   1. MethodCallExpression(op_Implicit, [array_expr]) — extract array_expr directly
+        ///   2. InvocationExpression(ConstantExpression(pre_compiled_delegate), []) — extract array
+        ///      from the delegate's closure target via reflection
+        /// </summary>
+        private static Expression TryExtractArrayFromSpanExpression(Expression spanExpr) {
+            // Pattern 1: MethodCallExpression — op_Implicit(array)
+            if (spanExpr is MethodCallExpression mc && mc.Arguments.Count == 1)
+                return mc.Arguments[0];
+
+            // Pattern 2: InvocationExpression(ConstantExpression(delegate), [])
+            // The compiler pre-compiled the implicit conversion to a zero-arg delegate.
+            // Extract the array from the delegate's closure.
+            if (spanExpr is InvocationExpression { Arguments.Count: 0 } invoke
+                && invoke.Expression is ConstantExpression constExpr
+                && constExpr.Value is Delegate del
+                && del.Target != null) {
+                var target = del.Target;
+                var elementType = spanExpr.Type.GetGenericArguments()[0];
+                var arrayType = elementType.MakeArrayType();
+                var arrayField = target.GetType()
+                    .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                    .FirstOrDefault(f => f.FieldType == arrayType);
+                if (arrayField != null)
+                    return Expression.Constant(arrayField.GetValue(target), arrayType);
+            }
+
+            return null;
+        }
+
         private SqlNode VisitContains(Expression sequence, Expression value) {
             Type elemType = TypeSystem.GetElementType(sequence.Type);
             SqlNode seqNode = this.Visit(sequence);
@@ -1880,15 +1912,19 @@ namespace System.Data.Linq.SqlClient {
                     return this.VisitSequenceOperatorCall(mc);
                 }
                 // In .NET 10, array.Contains(value) in expression trees compiles to
-                // MemoryExtensions.Contains(ReadOnlySpan<T>.op_Implicit(array), value).
-                // Translate the same as Enumerable.Contains(array, value).
+                // MemoryExtensions.Contains(ReadOnlySpan<T> span, value).
+                // Two compiler patterns exist for the span argument:
+                //   1. MethodCallExpression(op_Implicit, [array]) — simple local capture
+                //   2. InvocationExpression(ConstantExpression(pre_compiled_delegate), []) — nested closure
+                // Both must be unwrapped to extract the underlying array for SQL IN translation.
                 else if (mc.Method.DeclaringType == typeof(MemoryExtensions)
                     && mc.Method.Name == "Contains"
-                    && mc.Arguments[0] is MethodCallExpression spanConversion
-                    && spanConversion.Method.ReturnType is { IsGenericType: true } returnType
-                    && returnType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>)
-                    && spanConversion.Arguments.Count == 1) {
-                    return this.VisitContains(spanConversion.Arguments[0], mc.Arguments[1]);
+                    && mc.Arguments[0].Type is { IsGenericType: true } spanType
+                    && spanType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>)) {
+                    var arrayExpr = TryExtractArrayFromSpanExpression(mc.Arguments[0]);
+                    if (arrayExpr != null) {
+                        return this.VisitContains(arrayExpr, mc.Arguments[1]);
+                    }
                 }
                 else if (IsDataManipulationCall(mc)) {
                     return this.VisitDataManipulationCall(mc);

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -1884,7 +1884,10 @@ namespace System.Data.Linq.SqlClient {
                 // Translate the same as Enumerable.Contains(array, value).
                 else if (mc.Method.DeclaringType == typeof(MemoryExtensions)
                     && mc.Method.Name == "Contains"
-                    && mc.Arguments[0] is MethodCallExpression { Method.Name: "op_Implicit" } spanConversion) {
+                    && mc.Arguments[0] is MethodCallExpression spanConversion
+                    && spanConversion.Method.ReturnType is { IsGenericType: true } returnType
+                    && returnType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>)
+                    && spanConversion.Arguments.Count == 1) {
                     return this.VisitContains(spanConversion.Arguments[0], mc.Arguments[1]);
                 }
                 else if (IsDataManipulationCall(mc)) {

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -1884,10 +1884,7 @@ namespace System.Data.Linq.SqlClient {
                 // Translate the same as Enumerable.Contains(array, value).
                 else if (mc.Method.DeclaringType == typeof(MemoryExtensions)
                     && mc.Method.Name == "Contains"
-                    && mc.Arguments.Count == 2
-                    && mc.Arguments[0] is MethodCallExpression spanConversion
-                    && spanConversion.Method.Name == "op_Implicit"
-                    && spanConversion.Arguments.Count == 1) {
+                    && mc.Arguments[0] is MethodCallExpression { Method.Name: "op_Implicit" } spanConversion) {
                     return this.VisitContains(spanConversion.Arguments[0], mc.Arguments[1]);
                 }
                 else if (IsDataManipulationCall(mc)) {

--- a/Mindbox.Data.Linq/misc/SecurityUtils.cs
+++ b/Mindbox.Data.Linq/misc/SecurityUtils.cs
@@ -1,79 +1,214 @@
+//------------------------------------------------------------------------------
+// <copyright file="SecurityUtils.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
 using System;
 using System.Reflection;
+using System.Security;
+using System.Security.Permissions;
 
 namespace System.Data.Linq
 {
-    // Code Access Security (ReflectionPermission) is not supported on .NET 5+.
-    // This simplified version removes CAS checks which were no-ops on modern .NET.
-    internal static class SecurityUtils
-    {
-        internal static object SecureCreateInstance(Type type)
+    /// <devdoc>
+    ///     Useful methods to securely call 'dangerous' managed APIs (especially reflection).
+    ///     See http://wiki/default.aspx/Microsoft.Projects.DotNetClient.SecurityConcernsAroundReflection
+    ///     for more information specifically about why we need to be careful about reflection invocations.
+    /// </devdoc>
+    internal static class SecurityUtils {
+
+        private static volatile ReflectionPermission memberAccessPermission = null;
+        private static volatile ReflectionPermission restrictedMemberAccessPermission = null;
+
+        private static ReflectionPermission MemberAccessPermission
         {
+            get {
+                if (memberAccessPermission == null) {
+                    memberAccessPermission = new ReflectionPermission(ReflectionPermissionFlag.MemberAccess);
+                }
+                return memberAccessPermission;
+            }
+        }
+
+        private static ReflectionPermission RestrictedMemberAccessPermission {
+            get {
+                if (restrictedMemberAccessPermission == null) {
+                    restrictedMemberAccessPermission = new ReflectionPermission(ReflectionPermissionFlag.RestrictedMemberAccess);
+                }
+                return restrictedMemberAccessPermission;
+            }
+        }
+
+        private static void DemandReflectionAccess(Type type) {
+			MemberAccessPermission.Demand();
+		}
+
+        private static bool HasReflectionPermission(Type type) {
+            try {
+                DemandReflectionAccess(type);
+                return true;
+            }
+            catch (SecurityException) {
+            }
+
+            return false;
+        }
+
+       
+        /// <devdoc>
+        ///     This helper method provides safe access to Activator.CreateInstance.
+        ///     NOTE: This overload will work only with public .ctors. 
+        /// </devdoc>
+        internal static object SecureCreateInstance(Type type) {
             return SecureCreateInstance(type, null, false);
         }
 
-        internal static object SecureCreateInstance(Type type, object[] args, bool allowNonPublic)
-        {
-            if (type == null)
+
+        /// <devdoc>
+        ///     This helper method provides safe access to Activator.CreateInstance.
+        ///     Set allowNonPublic to true if you want non public ctors to be used. 
+        /// </devdoc>
+        internal static object SecureCreateInstance(Type type, object[] args, bool allowNonPublic) {
+            if (type == null) {
                 throw new ArgumentNullException("type");
+            }
 
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance;
-            if (allowNonPublic)
+           
+            // if it's an internal type, we demand reflection permission.
+            if (!type.IsVisible) {
+                DemandReflectionAccess(type);
+            }
+            else if (allowNonPublic && !HasReflectionPermission(type)) {
+                // Someone is trying to instantiate a public type in *our* assembly, but does not
+                // have full reflection permission. We shouldn't pass BindingFlags.NonPublic in this case.
+                // The reason we don't directly demand the permission here is because we don't know whether
+                // a public or non-public .ctor will be invoked. We want to allow the public .ctor case to
+                // succeed.
+                allowNonPublic = false;
+            }
+            
+            if (allowNonPublic) {
                 flags |= BindingFlags.NonPublic;
+            }
 
             return Activator.CreateInstance(type, flags, null, args, null);
         }
 
-        internal static object SecureCreateInstance(Type type, object[] args)
-        {
+        /// <devdoc>
+        ///     This helper method provides safe access to Activator.CreateInstance.
+        ///     NOTE: This overload will work only with public .ctors. 
+        /// </devdoc>
+        internal static object SecureCreateInstance(Type type, object[] args) {
             return SecureCreateInstance(type, args, false);
         }
 
-        internal static object SecureConstructorInvoke(Type type, Type[] argTypes, object[] args, bool allowNonPublic)
-        {
+
+        /// <devdoc>
+        ///     Helper method to safely invoke a .ctor. You should prefer SecureCreateInstance to this.
+        ///     Set allowNonPublic to true if you want non public ctors to be used. 
+        /// </devdoc>
+        internal static object SecureConstructorInvoke(Type type, Type[] argTypes, object[] args, bool allowNonPublic) {
             return SecureConstructorInvoke(type, argTypes, args, allowNonPublic, BindingFlags.Default);
         }
 
-        internal static object SecureConstructorInvoke(Type type, Type[] argTypes, object[] args,
-                                                       bool allowNonPublic, BindingFlags extraFlags)
-        {
-            if (type == null)
+        /// <devdoc>
+        ///     Helper method to safely invoke a .ctor. You should prefer SecureCreateInstance to this.
+        ///     Set allowNonPublic to true if you want non public ctors to be used. 
+        ///     The 'extraFlags' parameter is used to pass in any other flags you need, 
+        ///     besides Public, NonPublic and Instance.
+        /// </devdoc>
+        internal static object SecureConstructorInvoke(Type type, Type[] argTypes, object[] args, 
+                                                       bool allowNonPublic, BindingFlags extraFlags) {
+            if (type == null) {
                 throw new ArgumentNullException("type");
+            }
+   
+            // if it's an internal type, we demand reflection permission.
+            if (!type.IsVisible) {
+                DemandReflectionAccess(type);
+            }
+            else if (allowNonPublic && !HasReflectionPermission(type)) {
+                // Someone is trying to invoke a ctor on a public type, but does not
+                // have full reflection permission. We shouldn't pass BindingFlags.NonPublic in this case.
+                allowNonPublic = false;
+            }
 
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | extraFlags;
-            if (!allowNonPublic)
+            if (!allowNonPublic) {
                 flags &= ~BindingFlags.NonPublic;
+            }
 
             ConstructorInfo ctor = type.GetConstructor(flags, null, argTypes, null);
-            if (ctor != null)
+            if (ctor != null) {
                 return ctor.Invoke(args);
+            }
 
             return null;
         }
 
-        internal static object FieldInfoGetValue(FieldInfo field, object target)
-        {
-            if (field.DeclaringType == null)
+        private static bool GenericArgumentsAreVisible(MethodInfo method) {
+            if (method.IsGenericMethod) {
+                Type[] parameterTypes = method.GetGenericArguments();
+                foreach (Type type in parameterTypes) {
+                    if (!type.IsVisible) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+       
+        /// <devdoc>
+        ///     This helper method provides safe access to FieldInfo's GetValue method.
+        /// </devdoc>
+        internal static object FieldInfoGetValue(FieldInfo field, object target) {
+            Type type = field.DeclaringType;
+            if (type == null) {
+                // Type is null for Global fields.
                 throw new NotImplementedException("Global fields are not supported.");
-
+            } else if (!(type != null && type.IsVisible && field.IsPublic)) {
+                DemandReflectionAccess(type);
+            }
             return field.GetValue(target);
         }
 
-        internal static object MethodInfoInvoke(MethodInfo method, object target, object[] args)
-        {
-            if (method.DeclaringType == null)
-                throw new NotImplementedException("Global methods are not supported.");
-
+        /// <devdoc>
+        ///     This helper method provides safe access to MethodInfo's Invoke method.
+        /// </devdoc>
+        internal static object MethodInfoInvoke(MethodInfo method, object target, object[] args) {
+            Type type = method.DeclaringType;
+            if (type == null) {
+				// Type is null for Global methods. In this case we would need to demand grant set on 
+				// the containing assembly for internal methods.
+				throw new NotImplementedException("Global methods are not supported.");
+			} else if (!(type.IsVisible && method.IsPublic && GenericArgumentsAreVisible(method))) {
+                // this demand is required for internal types in system.dll and its friend assemblies. 
+                DemandReflectionAccess(type);
+            }
             return method.Invoke(target, args);
         }
 
-        internal static object ConstructorInfoInvoke(ConstructorInfo ctor, object[] args)
-        {
+        /// <devdoc>
+        ///     This helper method provides safe access to ConstructorInfo's Invoke method.
+        ///     Constructors can't be generic, so we don't check if argument types are visible
+        /// </devdoc>
+        internal static object ConstructorInfoInvoke(ConstructorInfo ctor, object[] args) {
+            Type type = ctor.DeclaringType;
+            if ((type != null) && !(type.IsVisible && ctor.IsPublic)) {
+                DemandReflectionAccess(type);
+            }
             return ctor.Invoke(args);
         }
 
-        internal static object ArrayCreateInstance(Type type, int length)
-        {
+        /// <devdoc>
+        ///     This helper method provides safe access to Array.CreateInstance.
+        /// </devdoc>
+        internal static object ArrayCreateInstance(Type type, int length) {
+            if (!type.IsVisible) {
+                DemandReflectionAccess(type);
+            }
             return Array.CreateInstance(type, length);
         }
     }

--- a/Mindbox.Data.Linq/misc/SecurityUtils.cs
+++ b/Mindbox.Data.Linq/misc/SecurityUtils.cs
@@ -1,214 +1,79 @@
-//------------------------------------------------------------------------------
-// <copyright file="SecurityUtils.cs" company="Microsoft">
-//     Copyright (c) Microsoft Corporation.  All rights reserved.
-// </copyright>
-//------------------------------------------------------------------------------
-
 using System;
 using System.Reflection;
-using System.Security;
-using System.Security.Permissions;
 
 namespace System.Data.Linq
 {
-    /// <devdoc>
-    ///     Useful methods to securely call 'dangerous' managed APIs (especially reflection).
-    ///     See http://wiki/default.aspx/Microsoft.Projects.DotNetClient.SecurityConcernsAroundReflection
-    ///     for more information specifically about why we need to be careful about reflection invocations.
-    /// </devdoc>
-    internal static class SecurityUtils {
-
-        private static volatile ReflectionPermission memberAccessPermission = null;
-        private static volatile ReflectionPermission restrictedMemberAccessPermission = null;
-
-        private static ReflectionPermission MemberAccessPermission
+    // Code Access Security (ReflectionPermission) is not supported on .NET 5+.
+    // This simplified version removes CAS checks which were no-ops on modern .NET.
+    internal static class SecurityUtils
+    {
+        internal static object SecureCreateInstance(Type type)
         {
-            get {
-                if (memberAccessPermission == null) {
-                    memberAccessPermission = new ReflectionPermission(ReflectionPermissionFlag.MemberAccess);
-                }
-                return memberAccessPermission;
-            }
-        }
-
-        private static ReflectionPermission RestrictedMemberAccessPermission {
-            get {
-                if (restrictedMemberAccessPermission == null) {
-                    restrictedMemberAccessPermission = new ReflectionPermission(ReflectionPermissionFlag.RestrictedMemberAccess);
-                }
-                return restrictedMemberAccessPermission;
-            }
-        }
-
-        private static void DemandReflectionAccess(Type type) {
-			MemberAccessPermission.Demand();
-		}
-
-        private static bool HasReflectionPermission(Type type) {
-            try {
-                DemandReflectionAccess(type);
-                return true;
-            }
-            catch (SecurityException) {
-            }
-
-            return false;
-        }
-
-       
-        /// <devdoc>
-        ///     This helper method provides safe access to Activator.CreateInstance.
-        ///     NOTE: This overload will work only with public .ctors. 
-        /// </devdoc>
-        internal static object SecureCreateInstance(Type type) {
             return SecureCreateInstance(type, null, false);
         }
 
-
-        /// <devdoc>
-        ///     This helper method provides safe access to Activator.CreateInstance.
-        ///     Set allowNonPublic to true if you want non public ctors to be used. 
-        /// </devdoc>
-        internal static object SecureCreateInstance(Type type, object[] args, bool allowNonPublic) {
-            if (type == null) {
+        internal static object SecureCreateInstance(Type type, object[] args, bool allowNonPublic)
+        {
+            if (type == null)
                 throw new ArgumentNullException("type");
-            }
 
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance;
-           
-            // if it's an internal type, we demand reflection permission.
-            if (!type.IsVisible) {
-                DemandReflectionAccess(type);
-            }
-            else if (allowNonPublic && !HasReflectionPermission(type)) {
-                // Someone is trying to instantiate a public type in *our* assembly, but does not
-                // have full reflection permission. We shouldn't pass BindingFlags.NonPublic in this case.
-                // The reason we don't directly demand the permission here is because we don't know whether
-                // a public or non-public .ctor will be invoked. We want to allow the public .ctor case to
-                // succeed.
-                allowNonPublic = false;
-            }
-            
-            if (allowNonPublic) {
+            if (allowNonPublic)
                 flags |= BindingFlags.NonPublic;
-            }
 
             return Activator.CreateInstance(type, flags, null, args, null);
         }
 
-        /// <devdoc>
-        ///     This helper method provides safe access to Activator.CreateInstance.
-        ///     NOTE: This overload will work only with public .ctors. 
-        /// </devdoc>
-        internal static object SecureCreateInstance(Type type, object[] args) {
+        internal static object SecureCreateInstance(Type type, object[] args)
+        {
             return SecureCreateInstance(type, args, false);
         }
 
-
-        /// <devdoc>
-        ///     Helper method to safely invoke a .ctor. You should prefer SecureCreateInstance to this.
-        ///     Set allowNonPublic to true if you want non public ctors to be used. 
-        /// </devdoc>
-        internal static object SecureConstructorInvoke(Type type, Type[] argTypes, object[] args, bool allowNonPublic) {
+        internal static object SecureConstructorInvoke(Type type, Type[] argTypes, object[] args, bool allowNonPublic)
+        {
             return SecureConstructorInvoke(type, argTypes, args, allowNonPublic, BindingFlags.Default);
         }
 
-        /// <devdoc>
-        ///     Helper method to safely invoke a .ctor. You should prefer SecureCreateInstance to this.
-        ///     Set allowNonPublic to true if you want non public ctors to be used. 
-        ///     The 'extraFlags' parameter is used to pass in any other flags you need, 
-        ///     besides Public, NonPublic and Instance.
-        /// </devdoc>
-        internal static object SecureConstructorInvoke(Type type, Type[] argTypes, object[] args, 
-                                                       bool allowNonPublic, BindingFlags extraFlags) {
-            if (type == null) {
+        internal static object SecureConstructorInvoke(Type type, Type[] argTypes, object[] args,
+                                                       bool allowNonPublic, BindingFlags extraFlags)
+        {
+            if (type == null)
                 throw new ArgumentNullException("type");
-            }
-   
-            // if it's an internal type, we demand reflection permission.
-            if (!type.IsVisible) {
-                DemandReflectionAccess(type);
-            }
-            else if (allowNonPublic && !HasReflectionPermission(type)) {
-                // Someone is trying to invoke a ctor on a public type, but does not
-                // have full reflection permission. We shouldn't pass BindingFlags.NonPublic in this case.
-                allowNonPublic = false;
-            }
 
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | extraFlags;
-            if (!allowNonPublic) {
+            if (!allowNonPublic)
                 flags &= ~BindingFlags.NonPublic;
-            }
 
             ConstructorInfo ctor = type.GetConstructor(flags, null, argTypes, null);
-            if (ctor != null) {
+            if (ctor != null)
                 return ctor.Invoke(args);
-            }
 
             return null;
         }
 
-        private static bool GenericArgumentsAreVisible(MethodInfo method) {
-            if (method.IsGenericMethod) {
-                Type[] parameterTypes = method.GetGenericArguments();
-                foreach (Type type in parameterTypes) {
-                    if (!type.IsVisible) {
-                        return false;
-                    }
-                }
-            }
-            return true;
-        }
-       
-        /// <devdoc>
-        ///     This helper method provides safe access to FieldInfo's GetValue method.
-        /// </devdoc>
-        internal static object FieldInfoGetValue(FieldInfo field, object target) {
-            Type type = field.DeclaringType;
-            if (type == null) {
-                // Type is null for Global fields.
+        internal static object FieldInfoGetValue(FieldInfo field, object target)
+        {
+            if (field.DeclaringType == null)
                 throw new NotImplementedException("Global fields are not supported.");
-            } else if (!(type != null && type.IsVisible && field.IsPublic)) {
-                DemandReflectionAccess(type);
-            }
+
             return field.GetValue(target);
         }
 
-        /// <devdoc>
-        ///     This helper method provides safe access to MethodInfo's Invoke method.
-        /// </devdoc>
-        internal static object MethodInfoInvoke(MethodInfo method, object target, object[] args) {
-            Type type = method.DeclaringType;
-            if (type == null) {
-				// Type is null for Global methods. In this case we would need to demand grant set on 
-				// the containing assembly for internal methods.
-				throw new NotImplementedException("Global methods are not supported.");
-			} else if (!(type.IsVisible && method.IsPublic && GenericArgumentsAreVisible(method))) {
-                // this demand is required for internal types in system.dll and its friend assemblies. 
-                DemandReflectionAccess(type);
-            }
+        internal static object MethodInfoInvoke(MethodInfo method, object target, object[] args)
+        {
+            if (method.DeclaringType == null)
+                throw new NotImplementedException("Global methods are not supported.");
+
             return method.Invoke(target, args);
         }
 
-        /// <devdoc>
-        ///     This helper method provides safe access to ConstructorInfo's Invoke method.
-        ///     Constructors can't be generic, so we don't check if argument types are visible
-        /// </devdoc>
-        internal static object ConstructorInfoInvoke(ConstructorInfo ctor, object[] args) {
-            Type type = ctor.DeclaringType;
-            if ((type != null) && !(type.IsVisible && ctor.IsPublic)) {
-                DemandReflectionAccess(type);
-            }
+        internal static object ConstructorInfoInvoke(ConstructorInfo ctor, object[] args)
+        {
             return ctor.Invoke(args);
         }
 
-        /// <devdoc>
-        ///     This helper method provides safe access to Array.CreateInstance.
-        /// </devdoc>
-        internal static object ArrayCreateInstance(Type type, int length) {
-            if (!type.IsVisible) {
-                DemandReflectionAccess(type);
-            }
+        internal static object ArrayCreateInstance(Type type, int length)
+        {
             return Array.CreateInstance(type, length);
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Mindbox.Data.Linq
+
+A fork of Microsoft's `System.Data.Linq` (LINQ to SQL) that enables multi-assembly extensibility and compatibility with modern .NET.
+
+## Why this fork?
+
+The original `System.Data.Linq` ships as a single sealed assembly. This fork splits the internals across multiple DLLs, making it possible to extend the query pipeline — custom SQL translators, mapping providers, and diagnostics hooks — without reflection hacks.
+
+## Target framework
+
+`net8.0`
+
+## Installation
+
+```
+dotnet add package Mindbox.Data.Linq
+```
+
+## Usage
+
+Drop-in replacement for `System.Data.Linq`. Replace the namespace import and use `DataContext` as usual:
+
+```csharp
+using System.Data.Linq;
+
+using var context = new DataContext(connectionString, mappingSource);
+var results = context.GetTable<Order>()
+    .Where(o => o.CustomerId == customerId)
+    .ToList();
+```
+
+## Key differences from System.Data.Linq
+
+| Feature | System.Data.Linq | Mindbox.Data.Linq |
+|---|---|---|
+| Multi-assembly extensibility | ✗ | ✓ |
+| .NET 10 `array.Contains()` in queries | ✗ | ✓ |
+| Target framework | netstandard2.0 | net8.0 |
+
+## Building
+
+```bash
+dotnet restore
+dotnet build --configuration Release
+dotnet test
+```
+
+## License
+
+MIT — see [LICENSE.txt](LICENSE.txt).


### PR DESCRIPTION
## Problem

`10.8.0` (PR #76) fixed `MemoryExtensions.Contains` for the simple case, but missed a second compiler pattern.

In .NET 10, `array.Contains(value)` in LINQ expression trees generates two patterns depending on closure structure:

1. `MethodCallExpression(op_Implicit, [array])` — simple local variable capture ✅ fixed in 10.8.0
2. `InvocationExpression(ConstantExpression(pre_compiled_delegate), [])` — nested closure (e.g. array passed as method parameter) ❌ still threw `NotSupportedException`

The `VisitInvocation` handler tried to `DynamicInvoke` the delegate but `ReadOnlySpan<T>` is a ref struct and cannot be returned via reflection — causing the crash.

## Fix

Added `TryExtractArrayFromSpanExpression()` helper that handles both patterns:
- **Pattern 1**: `MethodCallExpression(op_Implicit, [array_expr])` → return `array_expr`
- **Pattern 2**: `InvocationExpression(ConstantExpression(delegate), [])` → extract the array from the delegate's closure target via reflection

The entry condition is also broadened: checks `mc.Arguments[0].Type is ReadOnlySpan<T>` instead of requiring a specific `MethodCallExpression` shape.

## New test

`ArrayContains_PassedAsParameter_TranslatesToSqlIn` — reproduces pattern 2 (array captured in nested method scope), was RED before this fix.

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — **63 passed**, 17 skipped (net8.0 + net10.0)