### PR TITLE
fix: handle InvocationExpression pattern for MemoryExtensions.Contains (.NET 10)

### DIFF
--- a/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
+++ b/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
@@ -9,6 +9,10 @@ namespace Mindbox.Data.Linq.Tests
 	/// Tests that array.Contains(value) in LINQ queries is correctly translated to SQL IN clause.
 	/// In .NET 10, the C# compiler generates MemoryExtensions.Contains(ReadOnlySpan, value)
 	/// for this pattern instead of Enumerable.Contains — this must produce the same SQL.
+	/// Two compiler patterns exist:
+	/// 1. MethodCallExpression(op_Implicit, array) — simple closure capture
+	/// 2. InvocationExpression(ConstantExpression(delegate), []) — pre-compiled closure
+	/// Both must be handled.
 	/// </summary>
 	[TestClass]
 	public class ArrayContainsTranslationTests
@@ -22,6 +26,35 @@ namespace Mindbox.Data.Linq.Tests
 			using var context = new DataContext(connection);
 
 			var query = context.GetTable<SimpleEntity>().Where(t => ids.Contains(t.Id));
+
+			using var command = context.GetCommand(query);
+
+			Assert.AreEqual(
+				"SELECT [t0].[Id], [t0].[Discriminator], [t0].[X]" + Environment.NewLine +
+				"FROM [SimpleTable] AS [t0]" + Environment.NewLine +
+				"WHERE [t0].[Id] IN (@p0, @p1, @p2)",
+				command.CommandText);
+		}
+
+		/// <summary>
+		/// Reproduces the InvocationExpression pattern: when array is passed as a parameter
+		/// to a helper method and used in a Where clause, .NET 10 compiler may generate
+		/// InvocationExpression(ConstantExpression(pre_compiled_delegate), []) instead of
+		/// MethodCallExpression(op_Implicit, array_expr) for the implicit T[]→ReadOnlySpan conversion.
+		/// </summary>
+		[TestMethod]
+		public void ArrayContains_PassedAsParameter_TranslatesToSqlIn()
+		{
+			TranslateContainsQuery(new[] { 1, 2, 3 });
+		}
+
+		private static void TranslateContainsQuery(int[] ids)
+		{
+			using var connection = new DbConnectionStub();
+			using var context = new DataContext(connection);
+
+			var query = context.GetTable<SimpleEntity>()
+				.Where(t => ids.Contains(t.Id));
 
 			using var command = context.GetCommand(query);
 

--- a/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
+++ b/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
@@ -37,32 +37,30 @@ namespace Mindbox.Data.Linq.Tests
 		}
 
 		/// <summary>
-		/// Reproduces the InvocationExpression pattern: when array is passed as a parameter
-		/// to a helper method and used in a Where clause, .NET 10 compiler may generate
-		/// InvocationExpression(ConstantExpression(pre_compiled_delegate), []) instead of
-		/// MethodCallExpression(op_Implicit, array_expr) for the implicit T[]→ReadOnlySpan conversion.
+		/// Reproduces the InvocationExpression pattern: when array is passed as a method parameter,
+		/// .NET 10 compiler pre-compiles the implicit T[]→ReadOnlySpan conversion to a zero-arg delegate
+		/// (InvocationExpression) instead of keeping it as MethodCallExpression(op_Implicit).
 		/// </summary>
 		[TestMethod]
 		public void ArrayContains_PassedAsParameter_TranslatesToSqlIn()
 		{
-			TranslateContainsQuery(new[] { 1, 2, 3 });
-		}
+			RunWithIds(new[] { 1, 2, 3 });
 
-		private static void TranslateContainsQuery(int[] ids)
-		{
-			using var connection = new DbConnectionStub();
-			using var context = new DataContext(connection);
+			static void RunWithIds(int[] ids)
+			{
+				using var connection = new DbConnectionStub();
+				using var context = new DataContext(connection);
 
-			var query = context.GetTable<SimpleEntity>()
-				.Where(t => ids.Contains(t.Id));
+				var query = context.GetTable<SimpleEntity>().Where(t => ids.Contains(t.Id));
 
-			using var command = context.GetCommand(query);
+				using var command = context.GetCommand(query);
 
-			Assert.AreEqual(
-				"SELECT [t0].[Id], [t0].[Discriminator], [t0].[X]" + Environment.NewLine +
-				"FROM [SimpleTable] AS [t0]" + Environment.NewLine +
-				"WHERE [t0].[Id] IN (@p0, @p1, @p2)",
-				command.CommandText);
+				Assert.AreEqual(
+					"SELECT [t0].[Id], [t0].[Discriminator], [t0].[X]" + Environment.NewLine +
+					"FROM [SimpleTable] AS [t0]" + Environment.NewLine +
+					"WHERE [t0].[Id] IN (@p0, @p1, @p2)",
+					command.CommandText);
+			}
 		}
 
 		[TestMethod]

--- a/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
+++ b/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
@@ -37,9 +37,12 @@ namespace Mindbox.Data.Linq.Tests
 		}
 
 		/// <summary>
-		/// Reproduces the InvocationExpression pattern: when array is passed as a method parameter,
-		/// .NET 10 compiler pre-compiles the implicit T[]→ReadOnlySpan conversion to a zero-arg delegate
-		/// (InvocationExpression) instead of keeping it as MethodCallExpression(op_Implicit).
+		/// Reproduces the InvocationExpression compiler pattern.
+		/// When the array is captured via a method parameter (not a local variable), .NET 10 compiler
+		/// pre-compiles the implicit T[]→ReadOnlySpan conversion to a zero-arg delegate, producing
+		/// InvocationExpression(ConstantExpression(delegate), []) instead of MethodCallExpression(op_Implicit).
+		/// The nested local function RunWithIds is intentional — it is the minimal structure that triggers
+		/// this compiler pattern. Without it the test would be identical to ArrayContains_TranslatesToSqlIn.
 		/// </summary>
 		[TestMethod]
 		public void ArrayContains_PassedAsParameter_TranslatesToSqlIn()

--- a/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
+++ b/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Data.Linq;
 using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Mindbox.Data.Linq.Tests
@@ -64,6 +66,58 @@ namespace Mindbox.Data.Linq.Tests
 					"WHERE [t0].[Id] IN (@p0, @p1, @p2)",
 					command.CommandText);
 			}
+		}
+
+		/// <summary>
+		/// Directly constructs the InvocationExpression(ConstantExpression(delegate), []) pattern
+		/// using Expression API — guaranteed to exercise Pattern 2 regardless of compiler version.
+		/// The MemoryExtensions.Contains call is built by hand with a pre-compiled zero-arg delegate
+		/// as the span argument, matching exactly what .NET 10 generates in nested closure contexts.
+		/// </summary>
+		[TestMethod]
+		public void ArrayContains_InvocationExpressionPattern_TranslatesToSqlIn()
+		{
+			var ids = new[] { 1, 2, 3 };
+
+			// Build MemoryExtensions.Contains<int>(ReadOnlySpan<int>, int) method
+			var containsMethod = typeof(MemoryExtensions)
+				.GetMethods(BindingFlags.Public | BindingFlags.Static)
+				.Single(m => m.Name == "Contains"
+					&& m.IsGenericMethod
+					&& m.GetParameters() is [{ ParameterType: var p0 }, { ParameterType: { IsGenericParameter: true } }]
+					&& p0.IsGenericType
+					&& p0.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>))
+				.MakeGenericMethod(typeof(int));
+
+			// Build op_Implicit: int[] → ReadOnlySpan<int>
+			var opImplicit = typeof(ReadOnlySpan<int>)
+				.GetMethod("op_Implicit", new[] { typeof(int[]) });
+
+			// Pattern 2: the compiler pre-compiles the implicit conversion into a zero-arg delegate
+			// InvocationExpression(ConstantExpression(Func<ReadOnlySpan<int>>), [])
+			// Build: Func<ReadOnlySpan<int>> spanFactory = () => op_Implicit(ids)
+			var spanFactoryBody = Expression.Call(opImplicit, Expression.Constant(ids));
+			var spanFactory = Expression.Lambda(spanFactoryBody).Compile();
+			var spanExpr = Expression.Invoke(Expression.Constant(spanFactory));
+
+			// Build: WHERE t.Id IN (ids) via MemoryExtensions.Contains(spanExpr, t.Id)
+			var tParam = Expression.Parameter(typeof(SimpleEntity), "t");
+			var idMember = Expression.Property(tParam, nameof(SimpleEntity.Id));
+			var containsCall = Expression.Call(containsMethod, spanExpr, idMember);
+			var predicate = Expression.Lambda<Func<SimpleEntity, bool>>(containsCall, tParam);
+
+			using var connection = new DbConnectionStub();
+			using var context = new DataContext(connection);
+
+			var query = context.GetTable<SimpleEntity>().Where(predicate);
+
+			using var command = context.GetCommand(query);
+
+			Assert.AreEqual(
+				"SELECT [t0].[Id], [t0].[Discriminator], [t0].[X]" + Environment.NewLine +
+				"FROM [SimpleTable] AS [t0]" + Environment.NewLine +
+				"WHERE [t0].[Id] IN (@p0, @p1, @p2)",
+				command.CommandText);
 		}
 
 		[TestMethod]

--- a/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
+++ b/Mindbox.Data.Linq.Tests/SqlGeneration/ArrayContainsTranslationTests.cs
@@ -39,36 +39,6 @@ namespace Mindbox.Data.Linq.Tests
 		}
 
 		/// <summary>
-		/// Reproduces the InvocationExpression compiler pattern.
-		/// When the array is captured via a method parameter (not a local variable), .NET 10 compiler
-		/// pre-compiles the implicit T[]→ReadOnlySpan conversion to a zero-arg delegate, producing
-		/// InvocationExpression(ConstantExpression(delegate), []) instead of MethodCallExpression(op_Implicit).
-		/// The nested local function RunWithIds is intentional — it is the minimal structure that triggers
-		/// this compiler pattern. Without it the test would be identical to ArrayContains_TranslatesToSqlIn.
-		/// </summary>
-		[TestMethod]
-		public void ArrayContains_PassedAsParameter_TranslatesToSqlIn()
-		{
-			RunWithIds(new[] { 1, 2, 3 });
-
-			static void RunWithIds(int[] ids)
-			{
-				using var connection = new DbConnectionStub();
-				using var context = new DataContext(connection);
-
-				var query = context.GetTable<SimpleEntity>().Where(t => ids.Contains(t.Id));
-
-				using var command = context.GetCommand(query);
-
-				Assert.AreEqual(
-					"SELECT [t0].[Id], [t0].[Discriminator], [t0].[X]" + Environment.NewLine +
-					"FROM [SimpleTable] AS [t0]" + Environment.NewLine +
-					"WHERE [t0].[Id] IN (@p0, @p1, @p2)",
-					command.CommandText);
-			}
-		}
-
-		/// <summary>
 		/// Directly constructs the InvocationExpression(ConstantExpression(delegate), []) pattern
 		/// using Expression API — guaranteed to exercise Pattern 2 regardless of compiler version.
 		/// The MemoryExtensions.Contains call is built by hand with a pre-compiled zero-arg delegate

--- a/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
+++ b/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
@@ -8,7 +8,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageVersion>10.8.0$(VersionTag)</PackageVersion>
+    <PackageVersion>10.8.1$(VersionTag)</PackageVersion>
     <NoWarn>SYSLIB0003;SYSLIB0011</NoWarn>
   </PropertyGroup>
 

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -1774,17 +1774,10 @@ namespace System.Data.Linq.SqlClient {
             return new SqlUnary(aggType, clrType, sqlType, exp, this.dominatingExpression);
         }
 
-        // In .NET 10, array.Contains() generates two compiler patterns for T[]→ReadOnlySpan<T>:
-        //   1. MethodCallExpression(op_Implicit, [array_expr]) — simple local capture
-        //   2. InvocationExpression(ConstantExpression(pre_compiled_delegate), []) — nested closure
         /// <summary>
-        /// Searches for an array of the given type in a delegate's closure using BFS.
-        /// Handles two closure structures produced by the .NET runtime:
-        /// <list type="bullet">
-        ///   <item>Display class — a generated class with a direct T[] field (regular C# closure)</item>
-        ///   <item>Runtime Closure — Object[] fields (Constants/Locals) used by compiled expression lambdas,
-        ///         may be nested: outer Closure → inner Delegate → inner Closure with the actual array</item>
-        /// </list>
+        /// Searches for an array of the given type in a delegate's closure (BFS).
+        /// Handles direct T[] fields (display class) and Object[] fields (runtime Closure),
+        /// including nested delegates whose closures contain the array.
         /// </summary>
         private static object FindArrayInClosure(object root, Type arrayType) {
             var queue = new System.Collections.Generic.Queue<object>();

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -1813,7 +1813,7 @@ namespace System.Data.Linq.SqlClient {
             if (spanExpr is InvocationExpression { Arguments.Count: 0, Expression: ConstantExpression { Value: Delegate { Target: { } target } } }
                 && spanExpr.Type.GetGenericArguments() is [var elementType]) {
                 var arrayType = elementType.MakeArrayType();
-                var array = FindArrayInClosure(target, arrayType, depth: 0);
+                var array = FindArrayInClosure(target, arrayType);
                 if (array != null) {
                     return Expression.Constant(array, arrayType);
                 }

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -1775,30 +1775,28 @@ namespace System.Data.Linq.SqlClient {
         }
 
         /// <summary>
-        /// Searches for an array of the given type in a delegate's closure (BFS).
+        /// Searches for an array of the given type in a delegate's closure.
         /// Handles direct T[] fields (display class) and Object[] fields (runtime Closure),
-        /// including nested delegates whose closures contain the array.
+        /// including delegates nested inside Object[] fields (up to depth 3).
         /// </summary>
-        private static object FindArrayInClosure(object root, Type arrayType) {
-            var queue = new System.Collections.Generic.Queue<object>();
-            queue.Enqueue(root);
-            while (queue.Count > 0) {
-                var target = queue.Dequeue();
-                if (target == null) {
-                    continue;
+        private static object FindArrayInClosure(object target, Type arrayType, int depth = 0) {
+            if (target == null || depth > 3) {
+                return null;
+            }
+            foreach (var f in target.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
+                var val = f.GetValue(target);
+                if (val?.GetType() == arrayType) {
+                    return val;
                 }
-                foreach (var f in target.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
-                    var val = f.GetValue(target);
-                    if (val?.GetType() == arrayType) {
-                        return val;
-                    }
-                    if (val is object[] items) {
-                        foreach (var item in items) {
-                            if (item?.GetType() == arrayType) {
-                                return item;
-                            }
-                            if (item is Delegate nested && nested.Target != null) {
-                                queue.Enqueue(nested.Target);
+                if (val is object[] items) {
+                    foreach (var item in items) {
+                        if (item?.GetType() == arrayType) {
+                            return item;
+                        }
+                        if (item is Delegate nested && nested.Target != null) {
+                            var found = FindArrayInClosure(nested.Target, arrayType, depth + 1);
+                            if (found != null) {
+                                return found;
                             }
                         }
                     }
@@ -1815,7 +1813,7 @@ namespace System.Data.Linq.SqlClient {
             if (spanExpr is InvocationExpression { Arguments.Count: 0, Expression: ConstantExpression { Value: Delegate { Target: { } target } } }
                 && spanExpr.Type.GetGenericArguments() is [var elementType]) {
                 var arrayType = elementType.MakeArrayType();
-                var array = FindArrayInClosure(target, arrayType);
+                var array = FindArrayInClosure(target, arrayType, depth: 0);
                 if (array != null) {
                     return Expression.Constant(array, arrayType);
                 }

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -1774,6 +1774,38 @@ namespace System.Data.Linq.SqlClient {
             return new SqlUnary(aggType, clrType, sqlType, exp, this.dominatingExpression);
         }
 
+        /// <summary>
+        /// Extracts the underlying array/collection expression from a ReadOnlySpan expression.
+        /// In .NET 10, array.Contains() may generate two patterns for the implicit T[]→ReadOnlySpan conversion:
+        ///   1. MethodCallExpression(op_Implicit, [array_expr]) — extract array_expr directly
+        ///   2. InvocationExpression(ConstantExpression(pre_compiled_delegate), []) — extract array
+        ///      from the delegate's closure target via reflection
+        /// </summary>
+        private static Expression TryExtractArrayFromSpanExpression(Expression spanExpr) {
+            // Pattern 1: MethodCallExpression — op_Implicit(array)
+            if (spanExpr is MethodCallExpression mc && mc.Arguments.Count == 1)
+                return mc.Arguments[0];
+
+            // Pattern 2: InvocationExpression(ConstantExpression(delegate), [])
+            // The compiler pre-compiled the implicit conversion to a zero-arg delegate.
+            // Extract the array from the delegate's closure.
+            if (spanExpr is InvocationExpression { Arguments.Count: 0 } invoke
+                && invoke.Expression is ConstantExpression constExpr
+                && constExpr.Value is Delegate del
+                && del.Target != null) {
+                var target = del.Target;
+                var elementType = spanExpr.Type.GetGenericArguments()[0];
+                var arrayType = elementType.MakeArrayType();
+                var arrayField = target.GetType()
+                    .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                    .FirstOrDefault(f => f.FieldType == arrayType);
+                if (arrayField != null)
+                    return Expression.Constant(arrayField.GetValue(target), arrayType);
+            }
+
+            return null;
+        }
+
         private SqlNode VisitContains(Expression sequence, Expression value) {
             Type elemType = TypeSystem.GetElementType(sequence.Type);
             SqlNode seqNode = this.Visit(sequence);
@@ -1880,15 +1912,19 @@ namespace System.Data.Linq.SqlClient {
                     return this.VisitSequenceOperatorCall(mc);
                 }
                 // In .NET 10, array.Contains(value) in expression trees compiles to
-                // MemoryExtensions.Contains(ReadOnlySpan<T>.op_Implicit(array), value).
-                // Translate the same as Enumerable.Contains(array, value).
+                // MemoryExtensions.Contains(ReadOnlySpan<T> span, value).
+                // Two compiler patterns exist for the span argument:
+                //   1. MethodCallExpression(op_Implicit, [array]) — simple local capture
+                //   2. InvocationExpression(ConstantExpression(pre_compiled_delegate), []) — nested closure
+                // Both must be unwrapped to extract the underlying array for SQL IN translation.
                 else if (mc.Method.DeclaringType == typeof(MemoryExtensions)
                     && mc.Method.Name == "Contains"
-                    && mc.Arguments[0] is MethodCallExpression spanConversion
-                    && spanConversion.Method.ReturnType is { IsGenericType: true } returnType
-                    && returnType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>)
-                    && spanConversion.Arguments.Count == 1) {
-                    return this.VisitContains(spanConversion.Arguments[0], mc.Arguments[1]);
+                    && mc.Arguments[0].Type is { IsGenericType: true } spanType
+                    && spanType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>)) {
+                    var arrayExpr = TryExtractArrayFromSpanExpression(mc.Arguments[0]);
+                    if (arrayExpr != null) {
+                        return this.VisitContains(arrayExpr, mc.Arguments[1]);
+                    }
                 }
                 else if (IsDataManipulationCall(mc)) {
                     return this.VisitDataManipulationCall(mc);

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -1774,33 +1774,21 @@ namespace System.Data.Linq.SqlClient {
             return new SqlUnary(aggType, clrType, sqlType, exp, this.dominatingExpression);
         }
 
-        /// <summary>
-        /// Extracts the underlying array/collection expression from a ReadOnlySpan expression.
-        /// In .NET 10, array.Contains() may generate two patterns for the implicit T[]→ReadOnlySpan conversion:
-        ///   1. MethodCallExpression(op_Implicit, [array_expr]) — extract array_expr directly
-        ///   2. InvocationExpression(ConstantExpression(pre_compiled_delegate), []) — extract array
-        ///      from the delegate's closure target via reflection
-        /// </summary>
+        // In .NET 10, array.Contains() generates two compiler patterns for T[]→ReadOnlySpan<T>:
+        //   1. MethodCallExpression(op_Implicit, [array_expr]) — simple local capture
+        //   2. InvocationExpression(ConstantExpression(pre_compiled_delegate), []) — nested closure
         private static Expression TryExtractArrayFromSpanExpression(Expression spanExpr) {
-            // Pattern 1: MethodCallExpression — op_Implicit(array)
-            if (spanExpr is MethodCallExpression mc && mc.Arguments.Count == 1)
-                return mc.Arguments[0];
+            if (spanExpr is MethodCallExpression { Arguments: [var arrayExpr] })
+                return arrayExpr;
 
-            // Pattern 2: InvocationExpression(ConstantExpression(delegate), [])
-            // The compiler pre-compiled the implicit conversion to a zero-arg delegate.
-            // Extract the array from the delegate's closure.
-            if (spanExpr is InvocationExpression { Arguments.Count: 0 } invoke
-                && invoke.Expression is ConstantExpression constExpr
-                && constExpr.Value is Delegate del
-                && del.Target != null) {
-                var target = del.Target;
-                var elementType = spanExpr.Type.GetGenericArguments()[0];
+            if (spanExpr is InvocationExpression { Arguments.Count: 0, Expression: ConstantExpression { Value: Delegate { Target: { } target } } }
+                && spanExpr.Type.GetGenericArguments() is [var elementType]) {
                 var arrayType = elementType.MakeArrayType();
-                var arrayField = target.GetType()
-                    .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                var field = target.GetType()
+                    .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                     .FirstOrDefault(f => f.FieldType == arrayType);
-                if (arrayField != null)
-                    return Expression.Constant(arrayField.GetValue(target), arrayType);
+                if (field?.GetValue(target) is { } array)
+                    return Expression.Constant(array, arrayType);
             }
 
             return null;

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -1777,8 +1777,15 @@ namespace System.Data.Linq.SqlClient {
         // In .NET 10, array.Contains() generates two compiler patterns for T[]→ReadOnlySpan<T>:
         //   1. MethodCallExpression(op_Implicit, [array_expr]) — simple local capture
         //   2. InvocationExpression(ConstantExpression(pre_compiled_delegate), []) — nested closure
-        // Searches for an array of the given type in a delegate's closure using BFS.
-        // Handles display class (direct field), runtime Closure (Object[] fields), and nested delegates.
+        /// <summary>
+        /// Searches for an array of the given type in a delegate's closure using BFS.
+        /// Handles two closure structures produced by the .NET runtime:
+        /// <list type="bullet">
+        ///   <item>Display class — a generated class with a direct T[] field (regular C# closure)</item>
+        ///   <item>Runtime Closure — Object[] fields (Constants/Locals) used by compiled expression lambdas,
+        ///         may be nested: outer Closure → inner Delegate → inner Closure with the actual array</item>
+        /// </list>
+        /// </summary>
         private static object FindArrayInClosure(object root, Type arrayType) {
             var queue = new System.Collections.Generic.Queue<object>();
             queue.Enqueue(root);

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -1777,35 +1777,48 @@ namespace System.Data.Linq.SqlClient {
         // In .NET 10, array.Contains() generates two compiler patterns for T[]→ReadOnlySpan<T>:
         //   1. MethodCallExpression(op_Implicit, [array_expr]) — simple local capture
         //   2. InvocationExpression(ConstantExpression(pre_compiled_delegate), []) — nested closure
-        // Recursively searches for an array of the given type in a delegate's closure.
+        // Searches for an array of the given type in a delegate's closure using BFS.
         // Handles display class (direct field), runtime Closure (Object[] fields), and nested delegates.
-        private static object FindArrayInClosure(object target, Type arrayType, int depth) {
-            if (target == null || depth > 3) return null;
-            foreach (var f in target.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
-                var val = f.GetValue(target);
-                if (val?.GetType() == arrayType) return val;
-                if (val is object[] items)
-                    foreach (var item in items) {
-                        if (item?.GetType() == arrayType) return item;
-                        if (item is Delegate nested && nested.Target != null) {
-                            var found = FindArrayInClosure(nested.Target, arrayType, depth + 1);
-                            if (found != null) return found;
+        private static object FindArrayInClosure(object root, Type arrayType) {
+            var queue = new System.Collections.Generic.Queue<object>();
+            queue.Enqueue(root);
+            while (queue.Count > 0) {
+                var target = queue.Dequeue();
+                if (target == null) {
+                    continue;
+                }
+                foreach (var f in target.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
+                    var val = f.GetValue(target);
+                    if (val?.GetType() == arrayType) {
+                        return val;
+                    }
+                    if (val is object[] items) {
+                        foreach (var item in items) {
+                            if (item?.GetType() == arrayType) {
+                                return item;
+                            }
+                            if (item is Delegate nested && nested.Target != null) {
+                                queue.Enqueue(nested.Target);
+                            }
                         }
                     }
+                }
             }
             return null;
         }
 
         private static Expression TryExtractArrayFromSpanExpression(Expression spanExpr) {
-            if (spanExpr is MethodCallExpression { Arguments: [var arrayExpr] })
+            if (spanExpr is MethodCallExpression { Arguments: [var arrayExpr] }) {
                 return arrayExpr;
+            }
 
             if (spanExpr is InvocationExpression { Arguments.Count: 0, Expression: ConstantExpression { Value: Delegate { Target: { } target } } }
                 && spanExpr.Type.GetGenericArguments() is [var elementType]) {
                 var arrayType = elementType.MakeArrayType();
-                var array = FindArrayInClosure(target, arrayType, depth: 0);
-                if (array != null)
+                var array = FindArrayInClosure(target, arrayType);
+                if (array != null) {
                     return Expression.Constant(array, arrayType);
+                }
             }
 
             return null;

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -1777,6 +1777,25 @@ namespace System.Data.Linq.SqlClient {
         // In .NET 10, array.Contains() generates two compiler patterns for T[]→ReadOnlySpan<T>:
         //   1. MethodCallExpression(op_Implicit, [array_expr]) — simple local capture
         //   2. InvocationExpression(ConstantExpression(pre_compiled_delegate), []) — nested closure
+        // Recursively searches for an array of the given type in a delegate's closure.
+        // Handles display class (direct field), runtime Closure (Object[] fields), and nested delegates.
+        private static object FindArrayInClosure(object target, Type arrayType, int depth) {
+            if (target == null || depth > 3) return null;
+            foreach (var f in target.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)) {
+                var val = f.GetValue(target);
+                if (val?.GetType() == arrayType) return val;
+                if (val is object[] items)
+                    foreach (var item in items) {
+                        if (item?.GetType() == arrayType) return item;
+                        if (item is Delegate nested && nested.Target != null) {
+                            var found = FindArrayInClosure(nested.Target, arrayType, depth + 1);
+                            if (found != null) return found;
+                        }
+                    }
+            }
+            return null;
+        }
+
         private static Expression TryExtractArrayFromSpanExpression(Expression spanExpr) {
             if (spanExpr is MethodCallExpression { Arguments: [var arrayExpr] })
                 return arrayExpr;
@@ -1784,10 +1803,8 @@ namespace System.Data.Linq.SqlClient {
             if (spanExpr is InvocationExpression { Arguments.Count: 0, Expression: ConstantExpression { Value: Delegate { Target: { } target } } }
                 && spanExpr.Type.GetGenericArguments() is [var elementType]) {
                 var arrayType = elementType.MakeArrayType();
-                var field = target.GetType()
-                    .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-                    .FirstOrDefault(f => f.FieldType == arrayType);
-                if (field?.GetValue(target) is { } array)
+                var array = FindArrayInClosure(target, arrayType, depth: 0);
+                if (array != null)
                     return Expression.Constant(array, arrayType);
             }
 


### PR DESCRIPTION
## Problem

`10.8.0` (PR #76) fixed `MemoryExtensions.Contains` for Pattern 1, but missed Pattern 2.

In .NET 10, `array.Contains(value)` in LINQ expression trees generates two patterns for the implicit `T[]→ReadOnlySpan<T>` conversion:

1. `MethodCallExpression(op_Implicit, [array])` — simple local capture ✅ fixed in 10.8.0
2. `InvocationExpression(ConstantExpression(pre_compiled_delegate), [])` — closure compiled by DLR (e.g. after `ExpandExpressions()`) ❌ crashed

The `VisitInvocation` handler tried `DynamicInvoke` on the delegate, but `ReadOnlySpan<T>` is a ref struct — causing `NotSupportedException`.

## Fix

Added `FindArrayInClosure()` — recursive search over the delegate's closure (depth ≤ 3, no heap allocation). Handles:
- **Direct T[] field** (display class from regular C# closure)
- **Object[] Constants/Locals** (runtime `Closure` from compiled expression lambdas), including nested delegates

`TryExtractArrayFromSpanExpression()` now delegates to `FindArrayInClosure()` for Pattern 2.

## New test

`ArrayContains_InvocationExpressionPattern_TranslatesToSqlIn` — explicitly constructs Pattern 2 via `Expression.Lambda(...).Compile()`, was RED before this fix.

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — **63 passed**, 17 skipped (net8.0 + net10.0)