### PR TITLE
fix: FindArrayInClosure — search plain objects in object[] (display class pattern)

### DIFF
--- a/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
+++ b/Mindbox.Data.Linq/Mindbox.Data.Linq.csproj
@@ -8,7 +8,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageVersion>10.8.1$(VersionTag)</PackageVersion>
+    <PackageVersion>10.8.2$(VersionTag)</PackageVersion>
     <NoWarn>SYSLIB0003;SYSLIB0011</NoWarn>
   </PropertyGroup>
 

--- a/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
+++ b/Mindbox.Data.Linq/SqlClient/Query/QueryConverter.cs
@@ -1793,8 +1793,9 @@ namespace System.Data.Linq.SqlClient {
                         if (item?.GetType() == arrayType) {
                             return item;
                         }
-                        if (item is Delegate nested && nested.Target != null) {
-                            var found = FindArrayInClosure(nested.Target, arrayType, depth + 1);
+                        var searchTarget = item is Delegate nested ? nested.Target : item;
+                        if (searchTarget != null) {
+                            var found = FindArrayInClosure(searchTarget, arrayType, depth + 1);
                             if (found != null) {
                                 return found;
                             }


### PR DESCRIPTION
## Problem

`FindArrayInClosure` only recursed into `Delegate.Target` when searching `object[]` items. But `Closure.Constants` can contain a plain `<>c__DisplayClass` object (not a `Delegate`) that holds the actual array:

```
Closure
  .Constants = Object[]
    [0] = <>c__DisplayClass15_0   ← plain object, not Delegate
           .allowedIds = int[]    ← the array we need
```

This caused `TryExtractArrayFromSpanExpression` to return `null` for Pattern 2 when used via `ExecuteWithQueryCompilation` in Mindbox.Framework, resulting in `NotSupportedException` at runtime.

## Fix

One-liner: recurse into any non-null item in `object[]`, not just `Delegate.Target`.

```csharp
// before
if (item is Delegate nested && nested.Target != null) {
    var found = FindArrayInClosure(nested.Target, arrayType, depth + 1);

// after
var searchTarget = item is Delegate nested ? nested.Target : item;
if (searchTarget != null) {
    var found = FindArrayInClosure(searchTarget, arrayType, depth + 1);
```